### PR TITLE
Replace poksho submodule with 'git+' requirement

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,4 +1,0 @@
-[submodule "poksho"]
-	path = poksho
-	url = git@github.com:hpicrypto/poksho.git
-	branch = main

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 pytest~=7.2.0
 
 git+https://github.com/tgalal/python-curve25519-dalek@0.0.4#egg=curve25519-dalek
-./poksho
+git+https://github.com/hpicrypto/poksho.git@36a5b84301235ac8a31ea8173fcfb8a4b032a063#egg=poksho

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 pytest~=7.2.0
 
 git+https://github.com/tgalal/python-curve25519-dalek@0.0.4#egg=curve25519-dalek
-git+https://github.com/hpicrypto/poksho.git@36a5b84301235ac8a31ea8173fcfb8a4b032a063#egg=poksho
+git+https://github.com/hpicrypto/poksho.git@0.0.1#egg=poksho


### PR DESCRIPTION
We discussed this a while ago already: Replace poksho submodule with a proper entry in `requirements.txt`
This is particularly important to keep dependencies consistent for https://github.com/hpicrypto/zkgroup/