### PR TITLE
Make setup.py not 'import kvac' as this prevents installing kvac via pip

### DIFF
--- a/kvac/__init__.py
+++ b/kvac/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.0.1"
+__version__ = "0.0.2"
 
 from .issuer_key import IssuerPublicKey, IssuerKeyPair
 from .mac import MACTag, MAC

--- a/setup.py
+++ b/setup.py
@@ -1,12 +1,29 @@
 # -*- coding: utf-8 -*-
-import kvac
 from setuptools import find_packages, setup
+import codecs
+import os.path
+
+
+def read(rel_path):
+    here = os.path.abspath(os.path.dirname(__file__))
+    with codecs.open(os.path.join(here, rel_path), 'r') as fp:
+        return fp.read()
+
+
+def get_version(rel_path):
+    for line in read(rel_path).splitlines():
+        if line.startswith('__version__'):
+            delim = '"' if '"' in line else "'"
+            return line.split(delim)[1]
+    else:
+        raise RuntimeError("Unable to find version string.")
+
 
 setup(
     name='kvac',
-    version=kvac.__version__,
+    version=get_version("kvac/__init__.py"),
     packages=find_packages(exclude=['tests']),
-    install_requires=[],
+    install_requires=['poksho @ git+https://github.com/hpicrypto/poksho.git@0.0.1#egg=poksho'],
     tests_require=['pytest'],
     license='GNU Affero General Public License v3.0',
     author='',


### PR DESCRIPTION
As the title says, you should not import your `__init__.py` in your `setup.py` if it provides further imports, as this breaks the building process when the user has not yet installed the dependencies of `kvac` (i.e., `poksho`).

See https://packaging.python.org/en/latest/guides/single-sourcing-package-version/